### PR TITLE
use a vector to keep track of pseudolayers instead of a map

### DIFF
--- a/include/Objects/Cluster.h
+++ b/include/Objects/Cluster.h
@@ -405,7 +405,7 @@ private:
         unsigned int            m_nHits;                        ///< The number of hits in the pseudo layer
     };
 
-    typedef std::map<unsigned int, SimplePoint> PointByPseudoLayerMap;///< The point by pseudo layer typedef
+    typedef std::vector<SimplePoint> PointByPseudoLayerMap;     ///< The point by pseudo layer typedef
     typedef std::map<HitType, float> HitTypeToEnergyMap;        ///< The hit type to energy map typedef
 
     OrderedCaloHitList          m_orderedCaloHitList;           ///< The ordered calo hit list

--- a/src/Objects/Cluster.cc
+++ b/src/Objects/Cluster.cc
@@ -93,6 +93,8 @@ StatusCode Cluster::AddCaloHit(const CaloHit *const pCaloHit)
     m_hadronicEnergy += pCaloHit->GetHadronicEnergy();
 
     const unsigned int pseudoLayer(pCaloHit->GetPseudoLayer());
+    if( pseudoLayer >= m_sumXYZByPseudoLayer.size() ) m_sumXYZByPseudoLayer.resize(pseudoLayer+1);
+
     OrderedCaloHitList::const_iterator iter = m_orderedCaloHitList.find(pseudoLayer);
 
     if ((m_orderedCaloHitList.end() != iter) && (iter->second->size() > 1))
@@ -159,7 +161,11 @@ StatusCode Cluster::RemoveCaloHit(const CaloHit *const pCaloHit)
     }
     else
     {
-        m_sumXYZByPseudoLayer.erase(pseudoLayer);
+        SimplePoint &mypoint = m_sumXYZByPseudoLayer[pseudoLayer];
+        mypoint.m_xyzPositionSums[0] = 0.f;
+        mypoint.m_xyzPositionSums[1] = 0.f;
+        mypoint.m_xyzPositionSums[2] = 0.f;
+        mypoint.m_nHits = 0;
     }
 
     if (pseudoLayer <= m_innerPseudoLayer.Get())
@@ -215,12 +221,10 @@ StatusCode Cluster::RemoveIsolatedCaloHit(const CaloHit *const pCaloHit)
 
 const CartesianVector Cluster::GetCentroid(const unsigned int pseudoLayer) const
 {
-    PointByPseudoLayerMap::const_iterator pointValueIter = m_sumXYZByPseudoLayer.find(pseudoLayer);
-
-    if (m_sumXYZByPseudoLayer.end() == pointValueIter)
+    if ( m_sumXYZByPseudoLayer.size() <= pseudoLayer )
         throw StatusCodeException(STATUS_CODE_FAILURE);
 
-    const SimplePoint &mypoint = pointValueIter->second;
+    const SimplePoint &mypoint = m_sumXYZByPseudoLayer[pseudoLayer];
 
     if (0 == mypoint.m_nHits)
         throw StatusCodeException(STATUS_CODE_FAILURE);
@@ -372,7 +376,7 @@ StatusCode Cluster::ResetProperties()
     m_nPossibleMipHits = 0;
     m_nCaloHitsInOuterLayer = 0;
 
-    m_sumXYZByPseudoLayer.clear();
+    m_sumXYZByPseudoLayer.resize(0);
 
     m_electromagneticEnergy = 0;
     m_hadronicEnergy = 0;
@@ -437,6 +441,8 @@ StatusCode Cluster::AddHitsFromSecondCluster(const Cluster *const pCluster)
     {
         const unsigned int pseudoLayer(iter->first);
         OrderedCaloHitList::const_iterator currentIter = m_orderedCaloHitList.find(pseudoLayer);
+
+        if( pseudoLayer >=  m_sumXYZByPseudoLayer.size() )  m_sumXYZByPseudoLayer.resize(pseudoLayer+1);
 
         SimplePoint &mypoint = m_sumXYZByPseudoLayer[pseudoLayer];
         const SimplePoint &theirpoint = pCluster->m_sumXYZByPseudoLayer.at(pseudoLayer);


### PR DESCRIPTION
At least for 140PU there was a significantly fraction of time (15s/event) spent merely searching for the pseudolayer in the std::map.

Changed pandora::Cluster so that we use a vector instead and simply index it by the pseudolayer.
Should be sane in terms of memory use for most cases.